### PR TITLE
Add Runtipi manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ cd glpi-matrix-notifier
 
 ### 2. Configure Environment Variables
 
-Edit `docker-compose.yml` and set your 'container_name: NAME_CONTAINER'
-
 Create a `.env` file in the project root with the following keys:
 
 ```
@@ -57,6 +55,26 @@ View the application logs:
 ```bash
 docker-compose logs -f
 ```
+
+## Runtipi Integration
+
+This repository includes a minimal set of files to run the notifier as a
+Runtipi application. Clone the repository (or copy its files) inside the `apps`
+folder of your Runtipi installation and install it using the `runtipi-cli` tool:
+
+```bash
+sudo git clone https://github.com/SyNode-IT/glpi-matrix-notifier.git \
+    /opt/runtipi/apps/glpi-matrix-notifier
+cd /opt/runtipi/apps/glpi-matrix-notifier
+sudo cp -r runtipi/* .
+cd /opt/runtipi
+sudo ./runtipi-cli app install glpi-matrix-notifier
+```
+
+After installation, configure the environment variables from Tipi's interface
+(Apps → Manage) or by editing
+`/opt/runtipi/apps/glpi-matrix-notifier/config.json`, as explained in the
+[official documentation](https://runtipi.io/docs/guides/customize-app-config).
 
 ## License
 

--- a/runtipi/config.json
+++ b/runtipi/config.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "../app-info-schema.json",
+  "name": "GLPI Matrix Notifier",
+  "available": true,
+  "exposable": false,
+  "dynamic_config": true,
+  "id": "glpi-matrix-notifier",
+  "tipi_version": 20,
+  "version": "1.0.0",
+  "categories": ["utilities"],
+  "description": "Send GLPI ticket notifications to a Matrix room.",
+  "short_desc": "Notify Matrix on new GLPI tickets",
+  "author": "SyNode IT",
+  "source": "https://github.com/SyNode-IT/glpi-matrix-notifier",
+  "form_fields": [
+    {"type": "text", "label": "GLPI API URL", "env_variable": "GLPI_API_URL"},
+    {"type": "text", "label": "GLPI Username", "env_variable": "GLPI_USERNAME"},
+    {"type": "password", "label": "GLPI Password", "env_variable": "GLPI_PASSWORD"},
+    {"type": "text", "label": "GLPI App Token", "env_variable": "GLPI_APP_TOKEN"},
+    {"type": "text", "label": "Matrix Homeserver", "env_variable": "MATRIX_HOMESERVER"},
+    {"type": "text", "label": "Matrix Access Token", "env_variable": "MATRIX_TOKEN"},
+    {"type": "text", "label": "Room ID", "env_variable": "ROOM_ID"},
+    {"type": "text", "label": "Message", "env_variable": "MESSAGE"}
+  ],
+  "supported_architectures": ["arm64", "amd64"]
+}

--- a/runtipi/docker-compose.json
+++ b/runtipi/docker-compose.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../dynamic-compose-schema.json",
+  "services": [
+    {
+      "name": "glpi-matrix-notifier",
+      "build": {
+        "context": "..",
+        "dockerfile": "Dockerfile"
+      },
+      "environment": {
+        "GLPI_API_URL": "${GLPI_API_URL}",
+        "GLPI_USERNAME": "${GLPI_USERNAME}",
+        "GLPI_PASSWORD": "${GLPI_PASSWORD}",
+        "GLPI_APP_TOKEN": "${GLPI_APP_TOKEN}",
+        "MATRIX_HOMESERVER": "${MATRIX_HOMESERVER}",
+        "MATRIX_TOKEN": "${MATRIX_TOKEN}",
+        "ROOM_ID": "${ROOM_ID}",
+        "MESSAGE": "${MESSAGE}"
+      },
+      "isMain": true
+    }
+  ]
+}

--- a/runtipi/docker-compose.yml
+++ b/runtipi/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.8"
+services:
+  glpi-matrix-notifier:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    container_name: glpi-matrix-notifier
+    environment:
+      GLPI_API_URL: "${GLPI_API_URL}"
+      GLPI_USERNAME: "${GLPI_USERNAME}"
+      GLPI_PASSWORD: "${GLPI_PASSWORD}"
+      GLPI_APP_TOKEN: "${GLPI_APP_TOKEN}"
+      MATRIX_HOMESERVER: "${MATRIX_HOMESERVER}"
+      MATRIX_TOKEN: "${MATRIX_TOKEN}"
+      ROOM_ID: "${ROOM_ID}"
+      MESSAGE: "${MESSAGE}"
+    restart: unless-stopped

--- a/runtipi/metadata/description.md
+++ b/runtipi/metadata/description.md
@@ -1,0 +1,9 @@
+# GLPI Matrix Notifier
+
+This application monitors new tickets on a GLPI instance and forwards a message to a Matrix room.
+
+Place this repository under `/opt/runtipi/apps/glpi-matrix-notifier`, copy the
+files from the `runtipi` directory to the app folder, and run
+`./runtipi-cli app install glpi-matrix-notifier` from `/opt/runtipi` to deploy.
+After installation, configure the environment variables from Tipi's interface
+(Apps → Manage) or by editing `config.json`.

--- a/tests/test_script.py
+++ b/tests/test_script.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
+import asyncio
 import script
 
 
@@ -19,38 +20,38 @@ def test_init_glpi_session_success(mock_get, monkeypatch):
     assert token == 'abc123'
 
 
-@pytest.mark.asyncio
 @patch('script.aiohttp.ClientSession')
-async def test_send_matrix_message_success(mock_client_session, monkeypatch):
+def test_send_matrix_message_success(mock_client_session, monkeypatch):
     monkeypatch.setattr(script, 'MATRIX_HOMESERVER', 'http://matrix')
     monkeypatch.setattr(script, 'MATRIX_TOKEN', 'token')
     monkeypatch.setattr(script, 'ROOM_ID', 'room')
 
-    session_instance = AsyncMock()
+    session_instance = MagicMock()
     response_mock = AsyncMock()
     response_mock.__aenter__.return_value = response_mock
+    response_mock.__aexit__.return_value = False
     response_mock.status = 200
-    session_instance.put.return_value = response_mock
+    session_instance.put = MagicMock(return_value=response_mock)
     mock_client_session.return_value.__aenter__.return_value = session_instance
 
-    result = await script.send_matrix_message('hi')
+    result = asyncio.run(script.send_matrix_message('hi'))
     assert result is True
 
 
-@pytest.mark.asyncio
 @patch('script.aiohttp.ClientSession')
-async def test_send_matrix_message_failure(mock_client_session, monkeypatch):
+def test_send_matrix_message_failure(mock_client_session, monkeypatch):
     monkeypatch.setattr(script, 'MATRIX_HOMESERVER', 'http://matrix')
     monkeypatch.setattr(script, 'MATRIX_TOKEN', 'token')
     monkeypatch.setattr(script, 'ROOM_ID', 'room')
 
-    session_instance = AsyncMock()
+    session_instance = MagicMock()
     response_mock = AsyncMock()
     response_mock.__aenter__.return_value = response_mock
+    response_mock.__aexit__.return_value = False
     response_mock.status = 400
     response_mock.text = AsyncMock(return_value='error')
-    session_instance.put.return_value = response_mock
+    session_instance.put = MagicMock(return_value=response_mock)
     mock_client_session.return_value.__aenter__.return_value = session_instance
 
-    result = await script.send_matrix_message('hi')
+    result = asyncio.run(script.send_matrix_message('hi'))
     assert result is False


### PR DESCRIPTION
## Summary
- document installing the app on Runtipi without editing config.json directly
- create a Runtipi `config.json` manifest describing form fields
- provide a `docker-compose.json` file for dynamic compose
- drop the earlier `tipi.yml`
- clarify using `runtipi-cli` to install
- refine instructions for copying the runtipi directory
- explain using Tipi's interface to set environment variables

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cbdbe66748329b9e10446b11a0a48